### PR TITLE
🧵Chore: Swagger API 표시 순서 Alpha 순으로 고정

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -50,3 +50,9 @@ spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=10MB
 
 app.image.upload-dir=images
+
+# Tag Order by Alpha
+springdoc.swagger-ui.tags-sorter=alpha  
+# Method Order by Alpha
+springdoc.swagger-ui.operations-sorter=alpha  
+


### PR DESCRIPTION
# PollHub
# 🧵Chore: Swagger API 표시 순서 Alpha 순으로 고정